### PR TITLE
Fix release variant building and add baisc GitHub Action workflow for building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Test
+        run: ./gradlew test

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.activity.compose)
 
-    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling)
 
     screenshotTestImplementation(libs.androidx.compose.ui.tooling)
 }


### PR DESCRIPTION
1. Fix release variant building, see
https://github.com/android/compose-samples/blob/b95e8b3dfc77f764eafeeea6b1e54d6468809bd4/Jetcaster/wear/build.gradle#L118.
2. Add basic GitHub workflow for project's build and local testing.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
