### PR TITLE
CI: Integrate workflow_triggers for xr-samples from cartland's fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths-ignore:


### PR DESCRIPTION
This PR modifies GitHub Actions triggers in workflow files within .github/workflows/.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.
We are checking to make sure GitHub Actions are correctly using the following 3 triggers: workflow_dispatch, push, pull_request. This change modifies at least one of the following triggers:

1) `workflow_dispatch`: This trigger allows the workflow to be manually run in the GitHub UI. Most workflows should contain this trigger.
2) `push`: Most build and test scripts should run after a change is merged. This should at least run on the default branch, like `main`, but it could be configured to run on more branches.
3) `pull_request`: Most build and test scripts should run on pull requests, at least to the `main` branch.

Project Owner: Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.

